### PR TITLE
feat: iterator over rust range

### DIFF
--- a/python/python_calamine/_python_calamine.pyi
+++ b/python/python_calamine/_python_calamine.pyi
@@ -72,6 +72,22 @@ class CalamineSheet:
             For suppress this behaviour, set `skip_empty_area` to `False`.
         """
 
+    def iter_rows(
+        self,
+    ) -> typing.Iterator[
+        list[
+            int
+            | float
+            | str
+            | bool
+            | datetime.time
+            | datetime.date
+            | datetime.datetime
+            | datetime.timedelta
+        ]
+    ]:
+        """Retunrning data from sheet as iterator of lists."""
+
 @typing.final
 class CalamineWorkbook:
     path: str | None

--- a/src/types/cell.rs
+++ b/src/types/cell.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 use calamine::DataType;
 use pyo3::prelude::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CellValue {
     Int(i64),
     Float(f64),

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -180,6 +180,30 @@ def test_xlsx_read():
     assert [] == reader.get_sheet_by_index(1).to_python(skip_empty_area=False)
 
 
+def test_xlsx_iter_rows():
+    names = ["Sheet1", "Sheet2", "Sheet3"]
+    data = [
+        ["", "", "", "", "", "", "", "", "", ""],
+        [
+            "String",
+            1,
+            1.1,
+            True,
+            False,
+            date(2010, 10, 10),
+            datetime(2010, 10, 10, 10, 10, 10),
+            time(10, 10, 10),
+            timedelta(hours=10, minutes=10, seconds=10, microseconds=100000),
+            timedelta(hours=255, minutes=10, seconds=10),
+        ],
+    ]
+
+    reader = CalamineWorkbook.from_object(PATH / "base.xlsx")
+
+    assert names == reader.sheet_names
+    assert data == list(reader.get_sheet_by_index(0).iter_rows())
+
+
 def test_nrows():
     reader = CalamineWorkbook.from_object(PATH / "base.xlsx")
     sheet = reader.get_sheet_by_name("Sheet3")


### PR DESCRIPTION
* #42

Memory usage:
![Figure_1](https://github.com/dimastbk/python-calamine/assets/3132181/1e294cff-ab49-4984-88c0-503cf9830ebf)

- red - openpyxl, read_only=True, iter_rows()
- black - master, to_python()
- blue - this PR, iter_rows()

[example file](https://raw.githubusercontent.com/wiki/jqnatividad/qsv/files/NYC_311_SR_2010-2020-sample-1M.7z) (saved as xlsx in LibreOffice).

TODO: 
1. Fix empty cells and tests