### PR TITLE
perf: reduce memory in to_python() (return PyList instead of Vec)

### DIFF
--- a/src/types/cell.rs
+++ b/src/types/cell.rs
@@ -21,6 +21,12 @@ pub enum CellValue {
 
 impl IntoPy<PyObject> for CellValue {
     fn into_py(self, py: Python) -> PyObject {
+        self.to_object(py)
+    }
+}
+
+impl ToPyObject for CellValue {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
         match self {
             CellValue::Int(v) => v.to_object(py),
             CellValue::Float(v) => v.to_object(py),


### PR DESCRIPTION
Partial fix for #42. Return PyList instead of Vec - remove unnecessary reallocation.

![image](https://github.com/dimastbk/python-calamine/assets/3132181/22123dba-3ff5-4b1e-9819-6bc188d6fee9)
