### PR TITLE
Replace poetry dependencies specification with PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
+dependencies = [
+    "packaging~=23.1",
+]
 
 [tool.isort]
 include_trailing_comma = true
@@ -35,10 +38,6 @@ python-source = "python"
 
 [tool.poetry]
 package-mode = false
-
-[tool.poetry.dependencies]
-python = "^3.8"
-packaging = "^23.1"
 
 [tool.poetry.group.dev.dependencies]
 maturin = "^1.7.4"


### PR DESCRIPTION
## Issue

When installing `python-calamine` into my project via `pyproject.toml` on **Python 3.12** and using **PDM**, I was getting the following error:

```
File "/path/to/packages/python_calamine/pandas.py", line 8, in <module>
from packaging.version import Version, parse
ModuleNotFoundError: No module named 'packaging'
```

## Cause

- Poetry uses it's own non-standard syntax for dependencies (as it was developed first):
    ```toml
    [tool.poetry.dependencies]
    requests = "^2.13.0"
    ```
- Since then PEP 621 has been accepted, and the standard way to declare dependencies:
    ```toml
    [project]
    # ...
    dependencies = [
        "requests (>=2.23.0,<3.0.0)"
    ]
    ```
- Further details: https://python-poetry.org/docs/main/dependency-specification/#projectdependencies-and-toolpoetrydependencies
- For some reason I didn't get an error on Python 3.10 or 3.11, but this appeared on 3.12 🤷 
- The `packaging` dependency is not picked up by my dependency solver, and hence not installed at the same time as `python-calamine`.

## Solution

- Replace Poetry specific syntax with standard PEP 621 syntax.
- Specifying `python` as a dependency is not longer required, as this is covered by `requires-python`: https://peps.python.org/pep-0621/#requires-python
- Hopefully this change should mean that `packaging` is correctly installed alongside `python-calamine`.

> Note I didn't replace the `[tool.poetry.group.dev.dependencies]` with anything, as this is built tool specific. If this project uses poetry to manage other dependency groups then that is absolutely fine.