### PR TITLE
More flexible pinning of `packaging` dependency with `>=`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "packaging~=24.1",
+    "packaging>=23.1",
 ]
 
 [tool.isort]


### PR DESCRIPTION
Follow on from https://github.com/dimastbk/python-calamine/pull/93
Related to https://github.com/dimastbk/python-calamine/pull/95

- Devs installing this package should have the flexibility to pin as they need.
- We can't predict if a future version of `packaging` will have breaking changes, so shouldn't be restrictive with approximate pinning.
- I also downgraded the minimum version of packaging back to `v23.1`, which was working fine prior to the upgrade in https://github.com/dimastbk/python-calamine/pull/95.
- That version was released around a year and a half ago, which should give plenty of flexibility for a minimum.