### PR TITLE
Add CI to build pyodide package

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -253,8 +253,43 @@ jobs:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}
           path: dist
 
+  build-pyodide:
+    name: build pyodide wheel
+    permissions:
+      contents: read
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: install rust stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          target: wasm32-unknown-emscripten
+
+      - name: Install correct python version
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 #v6.3.0
+        with:
+          python-version: 3.14
+
+      - name: Build wheel
+        run: |
+          python3 -m pip install cibuildwheel==4.1.0
+          python3 -m cibuildwheel --output-dir dist
+        env:
+          CIBW_PLATFORM: pyodide
+
+      - run: ls -lh dist/
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-pyodide
+          path: dist
+
   release:
-    needs: [build, check]
+    needs: [build, build-pyodide, check]
     if: success() && startsWith(github.ref, 'refs/tags/')
 
     runs-on: ubuntu-latest
@@ -278,7 +313,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1.14
 
   gh-release:
-    needs: [build, check]
+    needs: [build, build-pyodide, check]
     if: success() && startsWith(github.ref, 'refs/tags/')
 
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,8 @@ build-backend = "maturin"
 [tool.maturin]
 module-name = "python_calamine._python_calamine"
 python-source = "python"
+
+[tool.cibuildwheel.pyodide]
+build = "cp314-*"
+test-requires = ["pytest"]
+test-command = "python -m pytest {project}/tests -x"


### PR DESCRIPTION
With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now build and publish Pyodide-compatible wheels (pyemscripten platform) directly to PyPI. Submiting this PR to build python package in python-calamine repository, so pyodide packages can be uploaded to PyPI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and publishing Pyodide-compatible wheels.
  * Pyodide artifacts are now included in the release process, so they’re available before package publication and GitHub releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->