### PR TITLE
tests: remove pandas 2.2 from ci and pandas 3.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,15 +28,17 @@ jobs:
           - "3.13"
           - "3.14"
         pandas-version:
-          - "2.2.*"
           - "2.3.*"
+          - "3.0.*"
         include:
           # https://github.com/pandas-dev/pandas/issues/42509
           - python-version: "pypy3.11"
             pandas-version: "none"
-          # https://github.com/pandas-dev/pandas/issues/60016
           - python-version: "3.14t"
-            pandas-version: "none"
+            pandas-version: "3.0.*"
+        exclude:
+          - python-version: "3.10"
+            pandas-version: "3.0.*"
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the automated test matrix to cover a newer supported dependency version.
  * Adjusted one test configuration to match the updated compatibility setup.
  * Added matrix exclusions to avoid unsupported version combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->