### PR TITLE
Upgrade calamine dependency to 0.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,11 +19,12 @@ dependencies = [
 
 [[package]]
 name = "atoi_simd"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
 dependencies = [
  "debug_unsafe",
+ "rustversion",
 ]
 
 [[package]]
@@ -46,9 +47,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "calamine"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8822fe6253ca47aa5ad9a3be09f6fe7cd20c6a74e41b0aa42e8f4e3d523508df"
+checksum = "6975084f43060e56343ffba7f9731fa52a7dcf2e1cd8e2459fd4c6bf4a1bff59"
 dependencies = [
  "atoi_simd",
  "byteorder",
@@ -383,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "encoding_rs",
  "memchr",
@@ -588,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.2.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "python_calamine"
 crate-type = ["cdylib"]
 
 [dependencies]
-calamine = { version = "0.35.0", features = ["chrono"] }
+calamine = { version = "0.36.0", features = ["chrono"] }
 pyo3 = { version = "0.29.0", features = [
     "extension-module",
     "chrono",

--- a/src/types/workbook.rs
+++ b/src/types/workbook.rs
@@ -79,23 +79,29 @@ impl SheetsEnum {
     ) -> Result<Option<Vec<calamine::Dimensions>>, Error> {
         match self {
             SheetsEnum::File(f) => match f {
-                Sheets::Xls(xls_f) => Ok(xls_f.worksheet_merge_cells(name)),
+                Sheets::Xls(xls_f) => xls_f
+                    .merge_cells_by_sheet_name(name)
+                    .map(Some)
+                    .map_err(CalamineCrateError::Xls)
+                    .map_err(Error::Calamine),
                 Sheets::Xlsx(xlsx_f) => xlsx_f
-                    .worksheet_merge_cells(name)
-                    .transpose()
+                    .merge_cells_by_sheet_name(name)
+                    .map(Some)
                     .map_err(CalamineCrateError::Xlsx)
-                    .map_err(Error::Calamine)
-                    .map(|inner| inner.or(Some(Vec::new()))),
+                    .map_err(Error::Calamine),
                 _ => Ok(None),
             },
             SheetsEnum::FileLike(f) => match f {
-                Sheets::Xls(xls_f) => Ok(xls_f.worksheet_merge_cells(name)),
+                Sheets::Xls(xls_f) => xls_f
+                    .merge_cells_by_sheet_name(name)
+                    .map(Some)
+                    .map_err(CalamineCrateError::Xls)
+                    .map_err(Error::Calamine),
                 Sheets::Xlsx(xlsx_f) => xlsx_f
-                    .worksheet_merge_cells(name)
-                    .transpose()
+                    .merge_cells_by_sheet_name(name)
+                    .map(Some)
                     .map_err(CalamineCrateError::Xlsx)
-                    .map_err(Error::Calamine)
-                    .map(|inner| inner.or(Some(Vec::new()))),
+                    .map_err(Error::Calamine),
                 _ => Ok(None),
             },
             SheetsEnum::None => Err(Error::WorkbookClosed),


### PR DESCRIPTION
Upgrade calamine from 0.35.0 to 0.36.0.

Changes:
- Bump calamine version in Cargo.toml
- Replace deprecated  with 
- Adapt to new return type:  instead of 
- Add error mapping for XLS merge cells path (previously returned Option)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worksheet merged-cell retrieval for XLS and XLSX files.
  * Standardized error handling across spreadsheet formats.
* **Maintenance**
  * Updated spreadsheet processing support to a newer version, improving compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->